### PR TITLE
Fix new core def files not being included in package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include examples/msg_defs/message.yaml
-include src/pyrtma/core_defs/core_defs.yaml
+include examples/msg_defs/*.yaml
+include src/pyrtma/core_defs/*.yaml

--- a/src/pyrtma/__version__.py
+++ b/src/pyrtma/__version__.py
@@ -1,7 +1,7 @@
 __title__ = "pyrtma"
 __description__ = "A Python compiler and client for RTMA/Dragonfly messaging system"
 __url__ = "https://github.com/pitt-rnel/pyrtma"
-__version__ = "2.3.0"
+__version__ = "2.3.1"
 __author__ = "RNEL"
 __author_email__ = ""
 __license__ = "MIT"


### PR DESCRIPTION
Updated manifest.in file to include all yaml files in core_defs and examples/msg_defs directories